### PR TITLE
Fix infinite loop until timeout

### DIFF
--- a/OpenRPA.NM/Activities/GetElement.cs
+++ b/OpenRPA.NM/Activities/GetElement.cs
@@ -144,7 +144,7 @@ namespace OpenRPA.NM
                     //}
                 }
 
-            } while (elements.Count() == 0 && sw.Elapsed < timeout);
+            } while (elements.Count() == 0 && allelements.Count() != 0 && sw.Elapsed < timeout);
             if (elements.Count() > maxresults) elements = elements.Take(maxresults).ToArray();
 
             if ((elements.Length + allelements.Length) < minresults)

--- a/OpenRPA.NM/Activities/GetElement.cs
+++ b/OpenRPA.NM/Activities/GetElement.cs
@@ -144,7 +144,7 @@ namespace OpenRPA.NM
                     //}
                 }
 
-            } while (elements.Count() == 0 && allelements.Count() != 0 && sw.Elapsed < timeout);
+            } while (elements.Count() == 0 && allelements.Length != 0 && sw.Elapsed < timeout);
             if (elements.Count() > maxresults) elements = elements.Take(maxresults).ToArray();
 
             if ((elements.Length + allelements.Length) < minresults)


### PR DESCRIPTION
There is a bug at the very beginning of getElement If the total elements are zero or do not exist. These causes send too many requests "getElement" until timeout.