### PR TITLE
Unpack inner OpenRPA.BusinessRuleException

### DIFF
--- a/OpenRPA/Activities/InvokeOpenRPA.cs
+++ b/OpenRPA/Activities/InvokeOpenRPA.cs
@@ -279,6 +279,10 @@ namespace OpenRPA.Activities
                 }
 
             }
+            catch (Exception ex) when (ex.InnerException is OpenRPA.BusinessRuleException)
+            {
+                throw ex.InnerException;
+            }
             catch (Exception ex)
             {
                 Log.Error(ex.ToString());


### PR DESCRIPTION
When a Business Rule Exception is thrown within a sub-workflow, it is returned as a regular System.Exception with an OpenRPA.BusinessRuleException as the inner exception. It contains information, that may be relevant for a technical/application exception (any other exception than a Business Rule Exception), such as in which workflow the error occured, and a stacktrace. This is not really relevant for Business Rule Exceptions. So I propose to unpack the BusinessRuleException so they will be correctly identified in the catch part of a try catch for instance.