### PR TITLE
feat: add `killworkflow` command and `noweblogin` config

### DIFF
--- a/OpenRPA.Interfaces/Config.cs
+++ b/OpenRPA.Interfaces/Config.cs
@@ -16,6 +16,8 @@ namespace OpenRPA
         public Dictionary<string, object> _properties = null;
         public Dictionary<string, object> properties { get { return GetProperty(null, new Dictionary<string, object>()); } set { SetProperty(null, value); } }
         public string wsurl { get { return GetProperty(null, "wss://app.openiap.io/"); } set { SetProperty(null, value); } }
+        //It will not open browser page for login if setted true and username/password (or unsafepassword) not null. Think about that username/password was provided and nobody could handle the browser login operation at the moment.
+        public bool noweblogin { get { return GetProperty(null, false); } set { SetProperty(null, value); } }
         public string username { get { return GetProperty(null, ""); } set { SetProperty(null, value); } }
         public byte[] jwt { get { return GetProperty<byte[]>(null, null); } set { SetProperty(null, value); } }
         public byte[] password { get { return GetProperty<byte[]>(null, null); } set { SetProperty(null, value); } }

--- a/OpenRPA/RobotInstance.cs
+++ b/OpenRPA/RobotInstance.cs
@@ -1677,6 +1677,38 @@ namespace OpenRPA
                     }
                     if (data != null) command.data = JObject.FromObject(data);
                 }
+                else if(command.command == "killworkflow")
+                {
+                    if (string.IsNullOrEmpty(command.workflowid)) throw new ArgumentException("expect workflow id");
+
+                    if (Config.local.remote_allowed_killing_any)
+                    {
+                        command.command = "killworkflowsuccess";
+                        string instanceid = null;
+                        if (command.data != null && command.data.ContainsKey("instanceid"))
+                        {
+                            instanceid = (string)command.data.GetValue("instanceid");
+                        }
+
+                        foreach (var i in WorkflowInstance.Instances.ToList())
+                        {
+                            if (command.workflowid == i.WorkflowId && (string.IsNullOrEmpty(instanceid) || instanceid == i._id))
+                            { //kill all instances of the workflow with `workflowid`,or just the specific instance if `instanceid` provided
+                                if (!i.isCompleted)
+                                {
+                                    i.Abort("Killed remotly by killworkflow command");
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        command.command = "error";
+                        command.data = JObject.FromObject(new Exception("kill workflow not allowed for " + global.webSocketClient.user + " running on " + System.Net.Dns.GetHostEntry(Environment.MachineName).HostName.ToLower()));
+                    }
+                    if (data != null) command.data = JObject.FromObject(data);
+                }
+
                 if (command.command == null) return;
                 if (command.command == "invoke" && !string.IsNullOrEmpty(command.workflowid))
                 {
@@ -1863,7 +1895,7 @@ namespace OpenRPA
                 };
             }
             // string data = Newtonsoft.Json.JsonConvert.SerializeObject(command);
-            if (command.command == "error" || command.command == "killallworkflowssuccess" || ((command.command == "invoke" || command.command == "invokesuccess") && !string.IsNullOrEmpty(command.workflowid)))
+            if (command.command == "error" || command.command == "killallworkflowssuccess" || command.command == "killworkflowsuccess" || ((command.command == "invoke" || command.command == "invokesuccess") && !string.IsNullOrEmpty(command.workflowid)))
             {
                 if (!string.IsNullOrEmpty(message.replyto) && message.replyto != message.queuename)
                 {

--- a/OpenRPA/RobotInstance.cs
+++ b/OpenRPA/RobotInstance.cs
@@ -1248,6 +1248,10 @@ namespace OpenRPA
                         {
                             Log.Error("RobotInstance.RobotInstance_WebSocketClient_OnOpen.userlogin: " + ex.Message);
                             errormessage = ex.Message;
+                            if (Config.local.noweblogin)
+                            {
+                                System.Threading.Thread.Sleep(3000);
+                            }
                         }
                     }
                     if (Config.local.jwt != null && Config.local.jwt.Length > 0)
@@ -1275,7 +1279,7 @@ namespace OpenRPA
                         }
                     }
                     if (global.webSocketClient == null || !global.webSocketClient.isConnected) return;
-                    if (user == null && global.webSocketClient.isConnected && !global.webSocketClient.signedin)
+                    if (user == null && global.webSocketClient.isConnected && !global.webSocketClient.signedin && !Config.local.noweblogin)
                     {
                         string jwt = null;
                         try

--- a/OpenRPA/WorkflowInstance.cs
+++ b/OpenRPA/WorkflowInstance.cs
@@ -201,7 +201,16 @@ namespace OpenRPA
                 }
             }
             else { throw new LockNotReceivedException("Failed adding new workflow instance in Create"); }
-            result.createApp(Workflow.Activity());
+            try
+            {
+                result.createApp(Workflow.Activity());
+            }
+            catch (Exception ex)
+            {
+                result.Abort("Create WorkflowApplication failed");
+                throw ex;
+            }
+            
             CleanUp();
             return result;
         }


### PR DESCRIPTION
1. [fix: Abort when "Create WorkflowApplication failed"](https://github.com/open-rpa/openrpa/commit/bad38d24654e2598c9a20d4ce9c14ef05e4833e6)
- The instance should be abort when creating WorkflowApplication failed.
2. [feat: add `killworkflow` command to kill specific instance remotely](https://github.com/open-rpa/openrpa/commit/1d1e4a3ab8171587d4a4b95bf7ec54a05cdf621e)
3. [feat: add `noweblogin` config. It will not open browser page for logi…](https://github.com/open-rpa/openrpa/commit/29797488642f3dffca8b01f101f67a7cedd9295e)
- `noweblogin` The default value is false.