### PR TITLE
Input a workflow name when create and Fix 3 bugs about python activity

### DIFF
--- a/OpenRPA.Script/Activities/InvokeCode.cs
+++ b/OpenRPA.Script/Activities/InvokeCode.cs
@@ -452,6 +452,58 @@ namespace OpenRPA.Script.Activities
                                                 else if (a.Value.ArgumentType == typeof(bool))
                                                 {
                                                     Arguments[a.Key].Set(context, bool.Parse(pyobj.ToString()));
+                                                }else if(a.Value.ArgumentType == typeof(object))
+                                                {
+                                                    if (PyString.IsStringType(pyobj))
+                                                    {
+                                                        Arguments[a.Key].Set(context, pyobj.ToString());
+                                                    }
+                                                    else if (PyNumber.IsNumberType(pyobj) && ("True" == pyobj.ToString() || "False" == pyobj.ToString()))
+                                                    {
+                                                        Arguments[a.Key].Set(context, bool.Parse(pyobj.ToString()));
+                                                    }
+                                                    else if (PyInt.IsIntType(pyobj))
+                                                    {
+                                                        Arguments[a.Key].Set(context, int.Parse(pyobj.ToString()));
+                                                    }
+                                                    else if (PyFloat.IsFloatType(pyobj))
+                                                    {
+                                                        Arguments[a.Key].Set(context, float.Parse(pyobj.ToString()));
+                                                    }else if (PyDict.IsDictType(pyobj))
+                                                    {
+                                                        try
+                                                        {
+                                                            var obj = Newtonsoft.Json.JsonConvert.DeserializeObject(pyobj.ToString(), typeof(JObject));
+                                                            Arguments[a.Key].Set(context, obj);
+                                                        }
+                                                        catch (Exception _ex)
+                                                        {
+                                                            Log.Information("Failed variable " + parameter.Key + " of type " + a.Value.ArgumentType.FullName + " " + _ex.Message);
+                                                        }
+                                                    }else if(PyList.IsListType(pyobj))
+                                                    {
+                                                        try
+                                                        {
+                                                            var obj = Newtonsoft.Json.JsonConvert.DeserializeObject(pyobj.ToString(), typeof(JArray));
+                                                            Arguments[a.Key].Set(context, obj);
+                                                        }
+                                                        catch (Exception _ex)
+                                                        {
+                                                            Log.Information("Failed variable " + parameter.Key + " of type " + a.Value.ArgumentType.FullName + " " + _ex.Message);
+                                                        }
+                                                    }
+                                                    else
+                                                    {
+                                                        try
+                                                        {
+                                                            var obj = Newtonsoft.Json.JsonConvert.DeserializeObject(pyobj.ToString(), a.Value.ArgumentType);
+                                                            Arguments[a.Key].Set(context, obj);
+                                                        }
+                                                        catch (Exception _ex)
+                                                        {
+                                                            Log.Information("Failed variable " + parameter.Key + " of type " + a.Value.ArgumentType.FullName + " " + _ex.Message);
+                                                        }
+                                                    }
                                                 }
                                                 else
                                                 {

--- a/OpenRPA.Script/Plugin.cs
+++ b/OpenRPA.Script/Plugin.cs
@@ -90,7 +90,11 @@ namespace OpenRPA.Script
             {
                 if (!Python.Included.Installer.IsPythonInstalled())
                 {
-                    Python.Included.Installer.SetupPython(true).Wait();
+                    Python.Included.Installer.SetupPython(true);//.Wait();
+                    while (!Python.Included.Installer.IsPythonInstalled())
+                    {
+                        Thread.Sleep(1000);
+                    }
                 }
                 else
                 {

--- a/OpenRPA/MainWindow.xaml.cs
+++ b/OpenRPA/MainWindow.xaml.cs
@@ -2390,9 +2390,17 @@ namespace OpenRPA
             Log.FunctionIndent("MainWindow", "OnNewWorkflow");
             try
             {
+                string Name = Project.UniqueName("New Workflow", null);
+                Name = Microsoft.VisualBasic.Interaction.InputBox("Name?", "Name Workflow", Name);
+                if (string.IsNullOrEmpty(Name))
+                {
+                    Log.FunctionOutdent("MainWindow", "OnNewWorkflow", "Name is null");
+                    return;
+                }
+
                 if (SelectedContent is Views.WFDesigner designer)
                 {
-                    Workflow workflow = await Workflow.Create(designer.Workflow.Project(), "New Workflow");
+                    Workflow workflow = await Workflow.Create(designer.Workflow.Project(), Name);
                     OnOpenWorkflow(workflow);
                     Log.FunctionOutdent("MainWindow", "OnNewWorkflow", "Designer selected");
                     return;
@@ -2402,21 +2410,21 @@ namespace OpenRPA
                 if (val is Detector d)
                 {
                     var project = RobotInstance.instance.Projects.Where(x => x._id == d.projectid).FirstOrDefault() as Project;
-                    Workflow workflow = await Workflow.Create(project, "New Workflow");
+                    Workflow workflow = await Workflow.Create(project, Name);
                     OnOpenWorkflow(workflow);
-                    Log.FunctionOutdent("MainWindow", "OnNewWorkflow", "Workflow selected");
+                    Log.FunctionOutdent("MainWindow", "OnNewWorkflow", Name);
                     return;
                 }
                 if (val is Workflow wf)
                 {
-                    Workflow workflow = await Workflow.Create(wf.Project(), "New Workflow");
+                    Workflow workflow = await Workflow.Create(wf.Project(), Name);
                     OnOpenWorkflow(workflow);
                     Log.FunctionOutdent("MainWindow", "OnNewWorkflow", "Workflow selected");
                     return;
                 }
                 if (val is Project p)
                 {
-                    Workflow workflow = await Workflow.Create(p, "New Workflow");
+                    Workflow workflow = await Workflow.Create(p, Name);
                     OnOpenWorkflow(workflow);
                     Log.FunctionOutdent("MainWindow", "OnNewWorkflow", "Project selected");
                     return;

--- a/OpenRPA/RobotInstance.cs
+++ b/OpenRPA/RobotInstance.cs
@@ -1811,6 +1811,10 @@ namespace OpenRPA
                                         {
                                             var v = k.Value.ToObject(typeof(Workitem));
                                             param.Add(k.Key, v);
+                                        }else if(k.Value.Type == JTokenType.Object && (p.type == typeof(JObject).FullName || p.type==typeof(object).FullName))
+                                        { 
+                                            // Type.GetType(p.type) may return null, so use typeof(JObject).FullName
+                                            param.Add(k.Key, k.Value.Value<JObject>());
                                         }
                                         else
                                         {

--- a/OpenRPA/RobotInstance.cs
+++ b/OpenRPA/RobotInstance.cs
@@ -1237,7 +1237,6 @@ namespace OpenRPA
                             Log.Debug("Signing in as " + Config.local.username + " " + string.Format("{0:mm\\:ss\\.fff}", sw.Elapsed));
                             user = await global.webSocketClient.Signin(Config.local.username, Config.local.UnprotectString(Config.local.password));
                             Log.Debug("Signed in as " + Config.local.username + " " + string.Format("{0:mm\\:ss\\.fff}", sw.Elapsed));
-                            Show();
                             SetStatus("Connected to " + Config.local.wsurl + " as " + user.name);
                             Show();
                             if (!string.IsNullOrEmpty(Config.local.unsafepassword))


### PR DESCRIPTION
## features
1. Show name input-box for new-workflow like new-project

## bugs
1. When installing OpenRPA for the first time, installing embedded Python will cause permanent blocking.
2. When the calling parameter type is JObject and the declared parameter is InArgument<Object> or InArgument<JObject>, the finally received parameter value is null.
3. When the declared parameter is OutArgument<Object>, "JsonConvert.DeserializeObject(pyobj.ToString(), a.Value.ArgumentType)" will most likely cause an exception