### PR TITLE
Fix `ScriptActivities` bug for `python 3.11` runtime

### DIFF
--- a/OpenRPA.Script/Activities/InvokeCode.cs
+++ b/OpenRPA.Script/Activities/InvokeCode.cs
@@ -98,6 +98,16 @@ namespace OpenRPA.Script.Activities
             Execute(context, code, language, Arguments, PipelineOutput);
         }
 
+        public static void InitPython()
+        {
+            if (python_doinit)
+            {
+                Python.Runtime.PythonEngine.Initialize();
+                _ = Python.Runtime.PythonEngine.BeginAllowThreads();
+                python_doinit = false;
+            }
+        }
+
         public void Execute(CodeActivityContext context, string code, string language, Dictionary<string, Argument> Arguments,
             OutArgument<Collection<System.Management.Automation.PSObject>> PipelineOutput)
         {
@@ -365,12 +375,7 @@ namespace OpenRPA.Script.Activities
                         IntPtr lck = IntPtr.Zero;
                         try
                         {
-                            if (python_doinit)
-                            {
-                                Python.Runtime.PythonEngine.Initialize();
-                                _ = Python.Runtime.PythonEngine.BeginAllowThreads();
-                                python_doinit = false;
-                            }
+                            InitPython();
                             // lck = PythonEngine.AcquireLock();
                             doRelease = true;
                             using (Python.Runtime.Py.GIL())

--- a/OpenRPA.Script/Activities/ScriptActivities.cs
+++ b/OpenRPA.Script/Activities/ScriptActivities.cs
@@ -527,7 +527,19 @@ namespace OpenRPA.Script.Activities
 
             if (language == "Python")
             {
-                args = ToPythonObject(args);
+                try
+                {
+                    InvokeCode.InitPython();
+                    using (Python.Runtime.Py.GIL())
+                    {
+                        args = ToPythonObject(args);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex.ToString());
+                    throw new Exception("Failed for 'ToPythonObject': " + ex.ToString());
+                }
             }
 
             rpa_args.Set(context, args);


### PR DESCRIPTION
**fix**: `new PyDict()` or `new PyList()` will cause error for `python 3.11` runtime.