### PR TITLE
Set some NM classes to public for further use in other projects.

### DIFF
--- a/OpenRPA.NM/NMSelector.cs
+++ b/OpenRPA.NM/NMSelector.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace OpenRPA.NM
 {
-    class NMSelector : Selector
+    public class NMSelector : Selector
     {
         NMElement element { get; set; }
         public NMSelector(string json) : base(json) { }

--- a/OpenRPA.NM/NMSelectorItem.cs
+++ b/OpenRPA.NM/NMSelectorItem.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace OpenRPA.NM
 {
-    class NMSelectorItem : SelectorItem
+    public class NMSelectorItem : SelectorItem
     {
         public NMSelectorItem() { }
         public NMSelectorItem(SelectorItem item)

--- a/OpenRPA.NM/PluginConfig.cs
+++ b/OpenRPA.NM/PluginConfig.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace OpenRPA.NM
 {
-    class PluginConfig
+    public class PluginConfig
     {
         private static string pluginname => "NM";
         private static Config _globallocal = null;


### PR DESCRIPTION
Set visibility of 3 classes to public so they can be referenced by other custom activities.